### PR TITLE
Ejemplo: Proporción, modificación código

### DIFF
--- a/rscripts/01-montecarlo.R
+++ b/rscripts/01-montecarlo.R
@@ -63,7 +63,7 @@ norm.cuadrature |>
 crear_log_post <- function(n, k){
   function(theta){
     verosim <- k * log(theta) + (n - k) * log(1 - theta)
-    inicial <- log(theta)
+    inicial <- log(2) + log(theta)
     verosim + inicial
   }
 }


### PR DESCRIPTION
La dist.  inicial está indicada como $p(\theta) = 2\theta$ pero en el código se consideró únicamente como $\theta$, por lo que se agrega la actualización.